### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI Flow
+permissions:
+  contents: read
 on:
   push:
     paths-ignore:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI Flow
 permissions:
   contents: read
+  checks: write
 on:
   push:
     paths-ignore:


### PR DESCRIPTION
Potential fix for [https://github.com/Templum/decorators/security/code-scanning/1](https://github.com/Templum/decorators/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions to `contents: read`, which is sufficient for the tasks performed in this workflow. This change ensures that the `GITHUB_TOKEN` has only the minimal permissions required, reducing the risk of unintended actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
